### PR TITLE
don't change casing of file names (in editor)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "auto-tfs",
-    "version": "1.3.4",
+    "version": "1.3.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "auto-tfs",
-            "version": "1.3.4",
+            "version": "1.3.5",
             "license": "MIT",
             "devDependencies": {
                 "@angular-eslint/eslint-plugin": "^15.1.0",

--- a/src/core/handler/impl/status-process-handler.ts
+++ b/src/core/handler/impl/status-process-handler.ts
@@ -60,8 +60,8 @@ export class StatusProcessHandler extends AbstractProcessHandler implements Proc
         if (previousChangeType === SCMChangeType.Pristine) {
             return;
         }
-        const f = localItemMatch[1].toLocaleLowerCase();
-        const index = f.indexOf(root.toLocaleLowerCase());
+        const f = localItemMatch[1];
+        const index = f.toLocaleLowerCase().indexOf(root.toLocaleLowerCase());
         const path = f.substring(index);
         this.addChange(path, previousChangeType, changes);
     }


### PR DESCRIPTION
My team needed to maintain the casing of the filenames and file extensions of the source control items, and they were being lowercased in the source control explorer. I don't think this changed the actual name of the file, but it conflicted with another VS Code extension which used the lowercased filename verbatim. If you clicked on an item from the source control explorer, you can see that the name of the editor tab was changed.